### PR TITLE
Add military helipad to military operations map

### DIFF
--- a/data/json/items/book/maps.json
+++ b/data/json/items/book/maps.json
@@ -46,6 +46,7 @@
         "bridge",
         "fema_entrance",
         "bunker",
+        "helipad",
         "outpost",
         { "om_terrain": "silo", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "shelter", "om_terrain_match_type": "TYPE" },


### PR DESCRIPTION
Ported from BN: [#2435](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2435) by [FlameStormer2000](https://github.com/FlameStormer2000)